### PR TITLE
Add GitHub helper method to transform URLS

### DIFF
--- a/src/org/integr8ly/GitHubUtils.groovy
+++ b/src/org/integr8ly/GitHubUtils.groovy
@@ -138,3 +138,22 @@ GHCommitStatus ghUpdatePrCommitStatus(GitHub gitHub, String prUrl, GHCommitState
   return ghUpdatePrCommitStatus(ghGetPullRequestFromUrl(gitHub, prUrl), state, targetUrl, description, context)
 }
 
+/**
+ * @param url - A GitHub project URL
+ * @param type - Type of URL required (https or ssh)
+ * @param webAccess - Should the URL be web accessible
+ * @returns transformed URL.
+ */
+static String ghTransformUrl(String url, type = 'https', webAccess = false) {
+    String transformedUrl
+    if(type == 'https') {
+        transformedUrl = url.replace("git@github.com:", "https://github.com/")
+        if(webAccess) {
+            transformedUrl = transformedUrl.replace('.git', '')
+        }
+    } else {
+        transformedUrl = url.replace("https://github.com/", "git@github.com:")
+    }
+    return transformedUrl
+}
+

--- a/vars/gitCreateAndCheckoutBranch.groovy
+++ b/vars/gitCreateAndCheckoutBranch.groovy
@@ -4,22 +4,23 @@
  * @param gitBranch - The git branch name to be created
  * @param useExistingBranch - Use an existing branch if found
  * @param pushOnCreate - Pushes the branch created locally to the remote git repository if set to true. Defaults to false
+ * @param remote - The name of the remote the branch should be created from/pushed to. Defaults to 'origin'
  * @return void
  */
-def call(String gitBranch, boolean useExistingBranch, boolean pushOnCreate = false) {
-  String remoteBranchCommit = sh(returnStdout: true, script: "git ls-remote origin refs/heads/${gitBranch} | cut -f 1").trim()
+def call(String gitBranch, boolean useExistingBranch = false, boolean pushOnCreate = false, String remote = 'origin') {
+    String remoteBranchCommit = sh(returnStdout: true, script: "git ls-remote ${remote} refs/heads/${gitBranch} | cut -f 1").trim()
 
-  if (remoteBranchCommit && useExistingBranch) {
-    sh "git checkout ${gitBranch}"
-  } else {
-    sh "git checkout -b ${gitBranch}"
+    if (remoteBranchCommit && useExistingBranch) {
+        sh "git checkout ${gitBranch}"
+    } else {
+        sh "git checkout -b ${gitBranch}"
 
-    if (pushOnCreate) {
-      if (params.dryRun) {
-        println "Would push the local branch '${gitBranch}' to the remote repository"
-      } else {
-        sh "git push origin ${gitBranch}"
-      }
+        if (pushOnCreate) {
+            if (params.dryRun) {
+                println "Would push the local branch '${gitBranch}' to the remote '${remote}' repository"
+            } else {
+                sh "git push ${remote} ${gitBranch}"
+            }
+        }
     }
-  }  
 }


### PR DESCRIPTION
* Add GitHub helper method to transform URLS between https and ssh (ghTransformUrl)
```
GitHubUtils.ghTransformUrl('git@github.com:integr8ly/installation.git', 'https', true)
-> https://github.com/integr8ly/installation
GitHubUtils.ghTransformUrl('https://github.com/integr8ly/installation.git', 'ssh')
-> git@github.com:integr8ly/installation.git
```
* Add optional remote parameter to gitCreateAndCheckoutBranch helper, defaults to 'origin'