### PR TITLE
Set consoleLogResponseBody to true for github api requests

### DIFF
--- a/src/org/integr8ly/GitHubUtils.groovy
+++ b/src/org/integr8ly/GitHubUtils.groovy
@@ -30,6 +30,7 @@ def ghApiRequest(String endpoint, String httpMethod = 'GET', String requestBody 
 
     def response = httpRequest httpMode: httpMethod,
                                 contentType: 'APPLICATION_JSON',
+                                consoleLogResponseBody: true, 
                                 requestBody: requestBody,
                                 customHeaders: customHeaders,
                                 url: url,


### PR DESCRIPTION
Set `consoleLogResponseBody` to true so we can see the response sent back by the API. This should allow us to determine the cause of request failures (i.e. rate limits/etc.)