### PR TITLE
INTLY-2248: Create getProductImages and getPreReleaseImages vars

### DIFF
--- a/vars/getPreReleaseImages.groovy
+++ b/vars/getPreReleaseImages.groovy
@@ -6,9 +6,9 @@ import org.integr8ly.RegistryImage
  * @param config { 
  *     imageUrls = List of product image urls to check against the target registry
  *     registryCredentials = The secret name to use in request authentication (username + password)
- *     targetRegistryHost = The registry host to check the image against
+ *     registryHost = The registry host to check the image against
  * }
- * @return List of product image urls found in the template directory
+ * @return List of prerelease images
  */
 def call(config) {
   def imageUrls = config.imageUrls ?: []
@@ -16,14 +16,13 @@ def call(config) {
 
   preReleaseImages = imageUrls.collect { imageUrl ->
     def image = new RegistryImage(imageUrl)
-    def params = [
-      credentials: config.registryCredentials,
-      host: config.targetRegistryHost ?: image.getHttpsHost(),
-      image: image.getPath(),
-      tag: image.getTag()
-    ]
-
     try {
+      def params = [
+        credentials: config.registryCredentials,
+        host: config.registryHost ?: image.getHttpsHost(),
+        image: image.getPath(),
+        tag: image.getTag()
+      ]
       registryHasImage(params) ? null : imageUrl
     } catch (Exception e) {
       println "Failed checking ${imageUrl}, adding image as prerelease"

--- a/vars/getPreReleaseImages.groovy
+++ b/vars/getPreReleaseImages.groovy
@@ -1,5 +1,7 @@
 #!/usr/bin/groovy
 
+import org.integr8ly.RegistryImage
+
 /**
  * @param config { 
  *     imageUrls = List of product image urls to check against the target registry
@@ -28,6 +30,6 @@ def call(config) {
       imageUrl
     }
   }.flatten() - null - ''
-  
+
   return preReleaseImages
 }

--- a/vars/getPreReleaseImages.groovy
+++ b/vars/getPreReleaseImages.groovy
@@ -1,0 +1,33 @@
+#!/usr/bin/groovy
+
+/**
+ * @param config { 
+ *     imageUrls = List of product image urls to check against the target registry
+ *     registryCredentials = The secret name to use in request authentication (username + password)
+ *     targetRegistryHost = The registry host to check the image against
+ * }
+ * @return List of product image urls found in the template directory
+ */
+def call(config) {
+  def imageUrls = config.imageUrls ?: []
+  def preReleaseImages = []
+
+  preReleaseImages = imageUrls.collect { imageUrl ->
+    def image = new RegistryImage(imageUrl)
+    def params = [
+      credentials: config.registryCredentials,
+      host: config.targetRegistryHost ?: image.getHttpsHost(),
+      image: image.getPath(),
+      tag: image.getTag()
+    ]
+
+    try {
+      registryHasImage(params) ? null : imageUrl
+    } catch (Exception e) {
+      println "Failed checking ${imageUrl}, adding image to productPreReleaseImages"
+      imageUrl
+    }
+  }.flatten() - null - ''
+  
+  return preReleaseImages
+}

--- a/vars/getPreReleaseImages.groovy
+++ b/vars/getPreReleaseImages.groovy
@@ -26,7 +26,7 @@ def call(config) {
     try {
       registryHasImage(params) ? null : imageUrl
     } catch (Exception e) {
-      println "Failed checking ${imageUrl}, adding image to productPreReleaseImages"
+      println "Failed checking ${imageUrl}, adding image as prerelease"
       imageUrl
     }
   }.flatten() - null - ''

--- a/vars/getProductImages.groovy
+++ b/vars/getProductImages.groovy
@@ -29,6 +29,7 @@ def call(config) {
         sh(returnStdout: true, script: "find . -name \'*.y*ml\' ${excludeFilesFlag} -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
       }
     }.flatten() - null - ''
+    productImages = productImages.unique()
   }
 
   return productImages

--- a/vars/getProductImages.groovy
+++ b/vars/getProductImages.groovy
@@ -21,8 +21,6 @@ def call(config) {
     excludeFilesFlag = "${excludeFilesFlag} ! -name \'${fileName}\'"
   }
 
-  println "excludeFilesFlag: ${excludeFilesFlag}"
-
   dir(targetDir) {
     productImages = registries.collect { registry ->
       registryIDs.collect { registryID ->

--- a/vars/getProductImages.groovy
+++ b/vars/getProductImages.groovy
@@ -1,0 +1,35 @@
+#!/usr/bin/groovy
+
+/**
+ * @param config { 
+ *     targetDir = Directory where the product templates and resources are located
+ *     excludeFiles = List of file names to be excluded from the search
+ *     registries = List of registries to look for
+ *     registryIDs = List of registry IDs to look for
+ * }
+ * @return List of product image urls found in the template directory
+ */
+def call(config) {
+  def targetDir = config.targetDir ?: '.'
+  def excludeFiles = config.excludeFiles ?: []
+  def registries = config.registries ?: []
+  def registryIDs = config.registryIDs ?: []
+  def productImages = []
+
+  def excludeFilesFlag = ""
+  excludeFiles.each{ fileName ->
+    excludeFilesFlag = "${excludeFilesFlag} ! -name \'${fileName}\'"
+  }
+
+  println "excludeFilesFlag: ${excludeFilesFlag}"
+
+  dir(targetDir) {
+    productImages = registries.collect { registry ->
+      registryIDs.collect { registryID ->
+        sh(returnStdout: true, script: "find . -name \'*.y*ml\' ${excludeFilesFlag} -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
+      }
+    }.flatten() - null - ''
+  }
+
+  return productImages
+}


### PR DESCRIPTION
Both the GA and RC service discovery jobs checks for the availability of the product images in the public registry to verify if the latest release discovered is GA/RC. Common code between these two should be extracted and moved to the library. 

- [x] Create `getProductImages` vars
- [x] Create `getPreReleaseImages` vars

NOTE: This should be tested with https://github.com/integr8ly/ci-cd/pull/197