### PR TITLE
Remove call to isValidAccessToken in registryHasImage.

### DIFF
--- a/vars/registryHasImage.groovy
+++ b/vars/registryHasImage.groovy
@@ -16,14 +16,6 @@ def call(config) {
     def token = utils.getAccessToken([
         credentials: config.credentials
     ])
-    def isValidToken = utils.isValidAccessToken([
-        host: config.host,
-        token: token
-    ])
-
-    if (!isValidToken) {
-        error '[ERROR] Registry authentication failed'
-    }
 
     return utils.tagExists([
         host: config.host,


### PR DESCRIPTION
It's started failing with a 404, and it's not really required since it's just adding an additional call for no real gain (It will fail in the same way on the actual call to check the image)